### PR TITLE
spell checker plugin 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
     browser: true,
     es6: true,
   },
+  plugins: ['spellcheck'],
   extends: ['eslint:recommended', 'airbnb-base'],
   parserOptions: {
     ecmaVersion: 12,
@@ -11,5 +12,16 @@ module.exports = {
   rules: {
     // default export 안해도 okay
     'import/prefer-default-export': 'off',
+    // spell check for eslint-config
+    'spellcheck/spell-checker': ['error', {
+      lang: 'en_US',
+      comments: false,
+      strings: false,
+      skipWords: [
+        'lang',
+        'jsx',
+        'ecma',
+      ],
+    }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "lint-staged": {
     "*.js": [
-       "yarn lint"
+      "yarn lint"
     ]
   },
   "files": [
@@ -31,6 +31,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-spellcheck": "^0.0.19",
     "prettier": "^2.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,15 @@ eslint-plugin-react@^7.25.1:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-spellcheck@^0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.19.tgz#73926b94208ae93ea5be00a8844dcdf1d8d2bf6f"
+  integrity sha512-Vau+oCLT3IGx+inJV5rkuKlIwgka9L2is1SkztviIHN3apNnT2OrZoGy9Jt3gbcjjkfkIFMFSZjB+ijHCimbNA==
+  dependencies:
+    globals "^13.0.0"
+    hunspell-spellchecker "^1.0.2"
+    lodash "^4.17.15"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -965,7 +974,7 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^13.6.0, globals@^13.9.0:
+globals@^13.0.0, globals@^13.6.0, globals@^13.9.0:
   version "13.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.11.0.tgz#40ef678da117fe7bd2e28f1fab24951bd0255be7"
   integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
@@ -1032,6 +1041,11 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+hunspell-spellchecker@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz#a10b0bd2fa00a65ab62a4c6b734ce496d318910e"
+  integrity sha1-oQsL0voAplq2Kkxrc0zkltMYkQ4=
 
 husky@^7.0.2:
   version "7.0.2"
@@ -1351,6 +1365,11 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
+lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## 변경내역
- Spell checker plugin 추가

## 확인이 필요한 부분
- rules 에 있는 skipWords 는 eslint-config 레포를 위한 spell checker skipWords 이고 각 프로젝트(frontend, admin, backend) 마다 다른 skipWords 가 필요할 수 있기 때문에 이는 각 레포에서 관리하는게 맞을것 같음

## 배포 전 해야 할 일
- [ ]

## 배포 후 해야 할 일
- diritto repo 에 spell checker plugin이 추가된 eslint-config 업뎃하기